### PR TITLE
Update vvctl to 2025.6.31

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751011381,
-        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
+        "lastModified": 1751271578,
+        "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
+        "rev": "3016b4b15d13f3089db8a41ef937b13a9e33a8df",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,11 +14,11 @@
       {
         packages.default = pkgs.stdenv.mkDerivation rec {
           pname = "vvctl";
-          version = "2025.6.30"; # Updated by workflow
+          version = "2025.6.31"; # Updated by workflow
           
           src = pkgs.fetchurl {
             url = "https://github.com/ververica/vvctl/releases/download/${version}/vvctl-${version}-x86_64-unknown-linux-gnu.tar.gz";
-            sha256 = "051b2e081210604ba4afc23b61766c5b4dfbd0f8b8379bb2e657d00cd86e6e1d"; # Updated by workflow
+            sha256 = "0f506b0342fc523cd78c71034e713ac3975a373e84156e473e7ae9ddee19500d"; # Updated by workflow
           };
 
           sourceRoot = ".";


### PR DESCRIPTION
Automated update of vvctl Nix flake to version 2025.6.31

    This PR updates:
    - Version to 2025.6.31
    - SHA256 hash for supported platforms
    - flake.lock dependencies

    The flake has been tested with `nix flake check`.